### PR TITLE
Replace `glsentryname` by `glsentrytext`

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,8 +12,8 @@ Use the codes below in place of the `\gls{label}` form in your source code:
 |`(++x)` | capitalised glossary entry                              | `\Gls{x}`            |
 |`(+^x)` | plural form of the glossary entry                       | `\glspl{x}`          |
 |`(++^x)`| capitalised plural form of the glossary entry           | `\Glspl{x}`          |
-|`(-x)`  | unlinked glossary entry name only                       | `\glsentryname{x}`   |
-|`(-+x)` | caplitalised unlinked glossary entry                    | `\Glsentryname{x}`   |
+|`(-x)`  | unlinked glossary entry name only                       | `\glsentrytext{x}`   |
+|`(-+x)` | caplitalised unlinked glossary entry                    | `\Glsentrytext{x}`   |
 |`(-^x)` | plutal unlinked glossary entry                          | `\glsentryplural{x}` |
 |`(-+^x)`| caplitalised plural form of the unlinked glossary entry | `\Glsentryplural{x}` |
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,8 +13,8 @@ Use the codes below in place of the `\gls{label}` form in your source code:
 |`(+^x)` | plural form of the glossary entry                       | `\glspl{x}`          |
 |`(++^x)`| capitalised plural form of the glossary entry           | `\Glspl{x}`          |
 |`(-x)`  | unlinked glossary entry name only                       | `\glsentrytext{x}`   |
-|`(-+x)` | caplitalised unlinked glossary entry                    | `\Glsentrytext{x}`   |
-|`(-^x)` | plutal unlinked glossary entry                          | `\glsentryplural{x}` |
+|`(-+x)` | capitalised unlinked glossary entry                     | `\Glsentrytext{x}`   |
+|`(-^x)` | plural unlinked glossary entry                          | `\glsentryplural{x}` |
 |`(-+^x)`| capitalised plural form of the unlinked glossary entry  | `\Glsentryplural{x}` |
 
 The unlinked versions of the syntax are recommended for figure and table captions as this

--- a/pandoc-gls.lua
+++ b/pandoc-gls.lua
@@ -31,9 +31,9 @@ function Str(el)
             elseif capital == "+" then
                 command = "gls"
             elseif capital == "-+" then
-                command = "Glsentryname"
+                command = "Glsentrytext"
             elseif capital == "-" then
-                command = "glsentryname"
+                command = "glsentrytext"
             else 
                 -- Unknown command string so just return the element unchanged
                 return el


### PR DESCRIPTION
In some advanced cases, the `name` and `text` fields may be distinct. However, adding a syntax to distinguish them seems overkill to me. `name` is the text printed in the glossary list nad `text` is the text printed in the document body. Knowing that `text` defaults to `name` if not defined, having a syntax for `\glsentrytext` seems to be the best approach to me.
